### PR TITLE
fix: 404 error on GitHub Pages

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,4 +1,4 @@
-import { createWebHistory, createRouter } from 'vue-router'
+import { createWebHashHistory, createRouter } from 'vue-router'
 
 import TheHomeView from '@/views/TheHome.vue'
 import WatchVideoView from '@/views/WatchVideo.vue'
@@ -11,7 +11,7 @@ const routes = [
 ]
 
 const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
+  history: createWebHashHistory(import.meta.env.BASE_URL),
   routes
 })
 


### PR DESCRIPTION
This PR fixes the 404 error thrown when refreshing the page (or when typing the URL), if deployed to GitHub Pages. This error does not occur when running on localhost.

The error is due to the fact that GitHub Pages does not currently support custom headers (and redirections), as mentioned in this discussion: https://github.com/orgs/community/discussions/27676

To fix this issue this PR changes the Vue Router to use hash mode routing, instead of HTML5 history mode as it was before. The issue is explained in more detail here: https://vue-land.github.io/faq/github-pages#vue-router
