### PR TITLE
test: try with .mp4 video

### DIFF
--- a/src/services/videos/data.json
+++ b/src/services/videos/data.json
@@ -4,7 +4,7 @@
     "duration": 25,
     "id": "6M125ll2ezP",
     "license": "Public domain",
-    "manifestUrl": "https://upload.wikimedia.org/wikipedia/commons/e/ef/Tortoise_laying_eggs.webm",
+    "manifestUrl": "https://www.sample-videos.com/video321/mp4/720/big_buck_bunny_720p_1mb.mp4",
     "thumbnailUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ef/Tortoise_laying_eggs.webm/640px--Tortoise_laying_eggs.webm.jpg",
     "title": "Tortoise laying eggs"
   },
@@ -13,7 +13,7 @@
     "duration": 35,
     "id": "lfmtNrhE0Dp",
     "license": "Public domain",
-    "manifestUrl": "https://upload.wikimedia.org/wikipedia/commons/e/e2/Florida_Panther_Trail_cam.webm",
+    "manifestUrl": "https://www.w3schools.com/html/mov_bbb.mp4",
     "thumbnailUrl": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Florida_Panther_Trail_cam.webm/640px--Florida_Panther_Trail_cam.webm.jpg",
     "title": "Florida Panther Trail cam"
   },


### PR DESCRIPTION
## Issue

#5  

## Description

This PR replaces a couple of .webm videos with .mp4 videos in the data file. This is done to test if these .mp4 videos play on Safari iOS.
