### PR TITLE
fix: allow video to play inline on Safari iOS

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -76,6 +76,6 @@ onUnmounted(async () => {
 
 <template>
   <div ref="videoContainerElement">
-    <video ref="videoElement" :poster="props.thumbnailPath" class="w-full"></video>
+    <video ref="videoElement" :poster="props.thumbnailPath" class="w-full" playsinline></video>
   </div>
 </template>


### PR DESCRIPTION
## Issue

#15 

## Description

This PR attempts to fix the issue by adding the attribute `playsinline` to the `<video>` element in the VideoPlayer component.

Related resources:
- https://webkit.org/blog/6784/new-video-policies-for-ios/
- https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/video#playsinline