### PR TITLE
fix(player): set enableFullscreenOnRotation and forceLandscapeOnFullscreen to false in UI configuration

### DIFF
--- a/src/components/VideoPlayer.vue
+++ b/src/components/VideoPlayer.vue
@@ -31,9 +31,13 @@ const initShakaPlayerUi = async () => {
       videoElement.value
     )
 
-    await player.attach(videoElement.value)
+    const config = {
+      enableFullscreenOnRotation: false,
+      forceLandscapeOnFullscreen: false
+    }
+    uiOverlay.configure(config)
 
-    uiOverlay.getControls()
+    await player.attach(videoElement.value)
 
     emitStatusChangeEvent('Shaka Player UI has been initialized.')
   } catch (error) {


### PR DESCRIPTION
## Issue

#14 

## Description

This PR attempts to fix the issue by setting the shaka UI configuration properties `enableFullscreenOnRotation` and `forceLandscapeOnFullscreen` to `false` in the VideoPlayer component.